### PR TITLE
Fix typo in secrets reference in build-stable workflow

### DIFF
--- a/.github/workflows/build-stable.yaml
+++ b/.github/workflows/build-stable.yaml
@@ -38,5 +38,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          token: ${{ secrets.geoip-policyd_RELEASE }}
+          token: ${{ secrets.geoip_policyd_RELEASE }}
           files: geoip-policyd-${{ matrix.goos }}-${{ matrix.goarch }}


### PR DESCRIPTION
Correct the token secret name from `geoip-policyd_RELEASE` to `geoip_policyd_RELEASE` in the GitHub Actions workflow. This ensures the release action uses the right secret for authentication.