### PR TITLE
Add GitHub Actions workflow for release automation

### DIFF
--- a/.github/workflows/build-stable.yaml
+++ b/.github/workflows/build-stable.yaml
@@ -5,38 +5,195 @@ on:
     tags:
       - '*'
 
+env:
+  APP_NAME: 'geoip-policyd'
+  MAINTAINER: 'croessner'
+  DESC: 'Policy server that blocks senders based on country and IP diversity.'
+
 jobs:
-  build:
-    name: Release Build on ${{ matrix.goos }} / ${{ matrix.goarch }}
+  build-artifact:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         goos: [linux]
         goarch: [amd64, arm64]
-
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.22.x
-
-      - name: Build project
-        run: |
+      - run: |
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
-          go build -mod=vendor -ldflags="-s -X main.version=${GITHUB_REF#refs/heads/})-${GITHUB_SHA:0:8}" -o geoip-policyd-${{ matrix.goos }}-${{ matrix.goarch }} .
+          go build -mod=vendor -ldflags="-s -X main.version=${GITHUB_REF#refs/heads/})-${GITHUB_SHA:0:8}" -o ${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }} .
+      - name: Create artifact
+        run: |
+          os="${{ runner.os }}"
+          assets="${{ env.APP_NAME }}_$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')"
+          echo "$assets"
+          mkdir -p "dist/$assets"
+          cp -r ${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }} LICENSE README.* "dist/$assets/"
+          (
+            tar czf "$assets.tar.gz" "$assets"
+            ls -lah *.*
+          )
+        shell: bash
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: geoip-policyd-${{ matrix.goos }}-${{ matrix.goarch }}-binary
-          path: geoip-policyd-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: artifact-${{ matrix.os }}
+          path: |
+            dist/*.tar.gz
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+  build-linux-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          token: ${{ secrets.geoip_policyd_RELEASE }}
-          files: geoip-policyd-${{ matrix.goos }}-${{ matrix.goarch }}
+          go-version: 1.22.x
+      - run: |
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
+          go build -mod=vendor -ldflags="-s -X main.version=${GITHUB_REF#refs/heads/})-${GITHUB_SHA:0:8}" -o ${{ env.APP_NAME }}-${{ matrix.goos }}
+
+      - name: Copy binaries
+        run: |
+          mkdir -p .debpkg/usr/bin
+          mkdir -p .rpmpkg/usr/bin
+          cp ${{ env.APP_NAME }}-${{ matrix.goos }} .debpkg/usr/sbin/
+          cp ${{ env.APP_NAME }}-${{ matrix.goos }} .rpmpkg/usr/sbin/
+      - uses: jiro4989/build-deb-action@v3
+        with:
+          package: ${{ env.APP_NAME }}
+          package_root: .debpkg
+          maintainer: ${{ env.MAINTAINER }}
+          version: ${{ github.ref }}
+          arch: 'amd64'
+          desc: '${{ env.DESC }}'
+
+      - uses: jiro4989/build-rpm-action@v2
+        with:
+          summary: '${{ env.DESC }}'
+          package: ${{ env.APP_NAME }}
+          package_root: .rpmpkg
+          maintainer: ${{ env.MAINTAINER }}
+          version: ${{ github.ref }}
+          arch: 'x86_64'
+          desc: '${{ env.DESC }}'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-deb
+          path: |
+            ./*.deb
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifact-rpm
+          path: |
+            ./*.rpm
+            !./*-debuginfo-*.rpm
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs:
+      - build-artifact
+      - build-linux-packages
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generate changelog
+        run: |
+          wget https://github.com/git-chglog/git-chglog/releases/download/0.9.1/git-chglog_linux_amd64
+          chmod +x git-chglog_linux_amd64
+          mv git-chglog_linux_amd64 git-chglog
+          ./git-chglog --output ./changelog $(git describe --tags $(git rev-list --tags --max-count=1))
+
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.geoip_policyd_RELEASE }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body_path: ./changelog
+          draft: false
+          prerelease: false
+
+      - name: Write upload_url to file
+        run: echo '${{ steps.create-release.outputs.upload_url }}' > upload_url.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: create-release
+          path: upload_url.txt
+
+  upload-release:
+    runs-on: ubuntu-latest
+    needs: create-release
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset_name_suffix: linux.tar.gz
+            asset_content_type: application/gzip
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: artifact-${{ matrix.os }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: create-release
+
+      - id: vars
+        run: |
+          echo "::set-output name=upload_url::$(cat upload_url.txt)"
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.geoip_policyd_RELEASE }}
+        with:
+          upload_url: ${{ steps.vars.outputs.upload_url }}
+          asset_path: ${{ env.APP_NAME }}_${{ matrix.asset_name_suffix }}
+          asset_name: ${{ env.APP_NAME }}_${{ matrix.asset_name_suffix }}
+          asset_content_type: ${{ matrix.asset_content_type }}
+
+  upload-linux-packages:
+    runs-on: ubuntu-latest
+    needs: create-release
+    strategy:
+      matrix:
+        include:
+          - pkg: deb
+            asset_content_type: application/vnd.debian.binary-package
+          - pkg: rpm
+            asset_content_type: application/x-rpm
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: artifact-${{ matrix.pkg }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: create-release
+
+      - id: vars
+        run: |
+          echo "::set-output name=upload_url::$(cat upload_url.txt)"
+          echo "::set-output name=asset_name::$(ls *.${{ matrix.pkg }} | head -n 1)"
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.geoip_policyd_RELEASE }}
+        with:
+          upload_url: ${{ steps.vars.outputs.upload_url }}
+          asset_path: ${{ steps.vars.outputs.asset_name }}
+          asset_name: ${{ steps.vars.outputs.asset_name }}
+          asset_content_type: ${{ matrix.asset_content_type }}


### PR DESCRIPTION
This commit introduces a comprehensive GitHub Actions workflow to automate the build, packaging, and release of the `geoip-policyd` project. It includes steps for building artifacts, creating Linux packages in both DEB and RPM formats, generating release changelogs, and uploading release assets to GitHub. This setup streamlines the release process and ensures consistency in the generated artifacts and release notes.