### PR TITLE
Fix: Fix incorrect GitHub reference in release upload

### DIFF
--- a/.github/workflows/build-stable.yaml
+++ b/.github/workflows/build-stable.yaml
@@ -141,7 +141,7 @@ jobs:
       - name: Upload Asset
         env:
           GH_TOKEN: ${{ secrets.GEOIP_POLICYD_TOKEN }}
-        run: gh release upload ${{ github.ref }} ${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.asset_suffix }}
+        run: gh release upload ${{ github.ref_name }} ${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.asset_suffix }}
 
   upload-linux-packages:
     runs-on: ubuntu-latest
@@ -170,4 +170,4 @@ jobs:
       - name: Upload Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GEOIP_POLICYD_TOKEN }}
-        run: gh release upload ${{ github.ref }} $ASSET_NAME
+        run: gh release upload ${{ github.ref_name }} $ASSET_NAME


### PR DESCRIPTION
Correct the GitHub reference from `github.ref` to `github.ref_name` in the workflow file to ensure the uploaded assets are correctly linked to the release. This change prevents potential issues with asset uploads during the release process.