### PR TITLE
Fix: Fix typo in build-stable.yaml version string

### DIFF
--- a/.github/workflows/build-stable.yaml
+++ b/.github/workflows/build-stable.yaml
@@ -25,7 +25,7 @@ jobs:
           go-version: 1.22.x
       - run: |
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
-          go build -mod=vendor -ldflags="-s -X main.version=${GITHUB_REF#refs/tags/})-${GITHUB_SHA:0:8}" -o ${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }} .
+          go build -mod=vendor -ldflags="-s -X main.version=${GITHUB_REF#refs/tags/}-${GITHUB_SHA:0:8}" -o ${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }} .
       - name: Create artifact
         run: |
           os="${{ runner.os }}"
@@ -62,7 +62,7 @@ jobs:
           go-version: 1.22.x
       - run: |
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} \
-          go build -mod=vendor -ldflags="-s -X main.version=${GITHUB_REF#refs/tags/})-${GITHUB_SHA:0:8}" -o ${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          go build -mod=vendor -ldflags="-s -X main.version=${GITHUB_REF#refs/tags/}-${GITHUB_SHA:0:8}" -o ${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}
 
       - name: Copy binaries
         run: |


### PR DESCRIPTION
Removed an erroneous closing parenthesis in the ldflags argument for the go build command. This ensures the version string is correctly formatted in the binary metadata.