### PR TITLE
Feat: Support multi-platform builds and extend image metadata

### DIFF
--- a/.github/workflows/docker-features.yaml
+++ b/.github/workflows/docker-features.yaml
@@ -33,3 +33,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/geoip-policyd:dev
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Policy server that blocks senders based on country and IP diversity

--- a/.github/workflows/docker-stable.yaml
+++ b/.github/workflows/docker-stable.yaml
@@ -33,3 +33,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/geoip-policyd:latest
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Policy server that blocks senders based on country and IP diversity

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine3.20 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.20 AS builder
 
 WORKDIR /build
 
@@ -17,11 +17,13 @@ RUN GIT_TAG=$(git describe --tags --abbrev=0) && echo "tag="${GIT_TAG}"" && \
 
 RUN cd ./stresstest && go build -mod vendor -v -ldflags="-s" -o stresstest main.go
 
-FROM alpine:3.20
+FROM --platform=$BUILDPLATFORM alpine:3.20
 
 LABEL org.opencontainers.image.authors="christian@roessner.email"
+LABEL org.opencontainers.image.source="https://github.com/croessner/geoip-policyd"
+LABEL org.opencontainers.image.description="Policy server that blocks senders based on country and IP diversity"
+LABEL org.opencontainers.image.licenses=AGPL-3
 LABEL com.roessner-network-solutions.vendor="Rößner-Network-Solutions"
-LABEL description="Postfix policy service that blocks clients, if they come from too many countires or IP addresses."
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
Enable multi-platform builds using the `--platform=$BUILDPLATFORM` directive for base images in Dockerfile. Add detailed labels to Dockerfile and include descriptions in GitHub workflows for better image metadata.