### PR TITLE
Fix: Update build script to use dynamic app name in systemd files

### DIFF
--- a/.github/workflows/build-stable.yaml
+++ b/.github/workflows/build-stable.yaml
@@ -32,9 +32,9 @@ jobs:
           assets="${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }}"
           echo "$assets"
           mkdir -p "dist/$assets"
-          cp -r ${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }} LICENSE README.* "dist/$assets/"
-          cp systemd/geoip-policyd.service "dist/$assets/"
-          cp systemd/geoip-policyd "dist/$assets/"
+          cp -r ${{ env.APP_NAME }}-${{ matrix.goos }}-${{ matrix.goarch }} LICENSE README.md "dist/$assets/"
+          cp systemd/${{ env.APP_NAME }}.service "dist/$assets/"
+          cp systemd/${{ env.APP_NAME }} "dist/$assets/"
           (
             cd dist
             tar czf "$assets.tar.gz" "$assets"


### PR DESCRIPTION
Adjusted the build-stable.yaml workflow file to dynamically use the application name for systemd service and executables. This ensures consistency and reduces the risk of errors if the application name changes. Also refined the README file handling to README.md explicitly.