### PR TITLE
Fix: Add version-specific Docker tags

### DIFF
--- a/.github/workflows/docker-stable.yaml
+++ b/.github/workflows/docker-stable.yaml
@@ -24,6 +24,17 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
 
+      - name: Extract tag versions
+        id: extract_version
+        run: |
+          tag=${GITHUB_REF##*/}  # gets the tag name, e.g., v1.2.3
+          major=$(echo $tag | cut -d'.' -f1)
+          minor=$(echo $tag | cut -d'.' -f2)
+          patch=$(echo $tag | cut -d'.' -f3)
+          echo "major=${major}" >> $GITHUB_ENV
+          echo "minor=${minor}" >> $GITHUB_ENV
+          echo "patch=${patch}" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -33,4 +44,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/geoip-policyd:latest
+            ghcr.io/${{ github.repository_owner }}/geoip-policyd:${{ env.major }}
+            ghcr.io/${{ github.repository_owner }}/geoip-policyd:${{ env.major }}.${{ env.minor }}
+            ghcr.io/${{ github.repository_owner }}/geoip-policyd:${{ env.major }}.${{ env.minor }}.${{ env.patch }}
           outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Policy server that blocks senders based on country and IP diversity


### PR DESCRIPTION
Implemented extraction of major, minor, and patch versions from tags. Updated the build-and-push step to push these specific version tags to the GitHub Container Registry.